### PR TITLE
Accept True and False as boolean constants

### DIFF
--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.0)
-project(ros_babel_fish)
+cmake_minimum_required(VERSION 3.5.1)
+project(ros_babel_fish VERSION 0.9.1)
 
 # If the value doesn't fit, an exception is thrown in any case because that could result in unexpected behavior and can not be ignored lightly
 option(WARN_ON_INCOMPATIBLE_TYPE "If ON a warning is printed if a value message is set or accessed with a type that does not allow casting without loss of information" ON)
@@ -145,8 +145,10 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rostest rosapi ros_babel_fish_test_msgs)
-  include_directories(${ros_babel_fish_test_msgs_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+  find_package(rostest REQUIRED)
+  find_package(rosapi REQUIRED)
+  find_package(ros_babel_fish_test_msgs REQUIRED)
+  include_directories(${ros_babel_fish_test_msgs_INCLUDE_DIRS} ${rosapi_INCLUDE_DIRS} ${rostest_INCLUDE_DIRS})
 
   add_rostest_gtest(${PROJECT_NAME}_test_message test/test_message.test test/message.cpp)
   target_link_libraries(${PROJECT_NAME}_test_message ${PROJECT_NAME})

--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -145,9 +145,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
-  find_package(ros_babel_fish_test_msgs REQUIRED)
-  include_directories(${ros_babel_fish_test_msgs_INCLUDE_DIRS})
+  find_package(catkin REQUIRED COMPONENTS rostest rosapi ros_babel_fish_test_msgs)
+  include_directories(${ros_babel_fish_test_msgs_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
   add_rostest_gtest(${PROJECT_NAME}_test_message test/test_message.test test/message.cpp)
   target_link_libraries(${PROJECT_NAME}_test_message ${PROJECT_NAME})

--- a/ros_babel_fish/src/generation/description_provider.cpp
+++ b/ros_babel_fish/src/generation/description_provider.cpp
@@ -212,9 +212,24 @@ MessageTemplate::Ptr DescriptionProvider::createTemplate( const MessageSpec &spe
   for ( auto &constant : spec.constants )
   {
     Message::Ptr value;
-    if ( constant.type == "bool" || constant.type == "uint8" || constant.type == "char" )
+    if ( constant.type == "uint8" || constant.type == "char" )
     {
       value = std::make_shared<ValueMessage<uint8_t>>( static_cast<uint8_t>(std::stoi( constant.val )));
+    }
+    else if ( constant.type == "bool")
+    {
+      if (constant.val == "True")
+      {
+        value = std::make_shared<ValueMessage<uint8_t>>(1);
+      }
+      else if (constant.val == "False")
+      {
+        value = std::make_shared<ValueMessage<uint8_t>>(0);
+      }
+      else
+      {
+        value = std::make_shared<ValueMessage<uint8_t>>(static_cast<uint8_t>(std::stoi(constant.val)));
+      }
     }
     else if ( constant.type == "int8" || constant.type == "byte" )
     {

--- a/ros_babel_fish/src/generation/description_provider.cpp
+++ b/ros_babel_fish/src/generation/description_provider.cpp
@@ -220,15 +220,15 @@ MessageTemplate::Ptr DescriptionProvider::createTemplate( const MessageSpec &spe
     {
       if ( constant.val == "True" )
       {
-        value = std::make_shared<ValueMessage<uint8_t>>( 1 );
+        value = std::make_shared<ValueMessage<bool>>( true );
       }
       else if ( constant.val == "False" )
       {
-        value = std::make_shared<ValueMessage<uint8_t>>( 0 );
+        value = std::make_shared<ValueMessage<bool>>( false );
       }
       else
       {
-        value = std::make_shared<ValueMessage<uint8_t>>( static_cast<uint8_t>(std::stoi( constant.val )));
+        value = std::make_shared<ValueMessage<bool>>( static_cast<bool>(std::stoi( constant.val )));
       }
     }
     else if ( constant.type == "int8" || constant.type == "byte" )

--- a/ros_babel_fish/src/generation/description_provider.cpp
+++ b/ros_babel_fish/src/generation/description_provider.cpp
@@ -216,19 +216,19 @@ MessageTemplate::Ptr DescriptionProvider::createTemplate( const MessageSpec &spe
     {
       value = std::make_shared<ValueMessage<uint8_t>>( static_cast<uint8_t>(std::stoi( constant.val )));
     }
-    else if ( constant.type == "bool")
+    else if ( constant.type == "bool" )
     {
-      if (constant.val == "True")
+      if ( constant.val == "True" )
       {
-        value = std::make_shared<ValueMessage<uint8_t>>(1);
+        value = std::make_shared<ValueMessage<uint8_t>>( 1 );
       }
-      else if (constant.val == "False")
+      else if ( constant.val == "False" )
       {
-        value = std::make_shared<ValueMessage<uint8_t>>(0);
+        value = std::make_shared<ValueMessage<uint8_t>>( 0 );
       }
       else
       {
-        value = std::make_shared<ValueMessage<uint8_t>>(static_cast<uint8_t>(std::stoi(constant.val)));
+        value = std::make_shared<ValueMessage<uint8_t>>( static_cast<uint8_t>(std::stoi( constant.val )));
       }
     }
     else if ( constant.type == "int8" || constant.type == "byte" )

--- a/ros_babel_fish/test/message_lookup.cpp
+++ b/ros_babel_fish/test/message_lookup.cpp
@@ -160,6 +160,28 @@ TEST( MessageLookupTest, messageOnlyDescriptionProvider )
                 BabelFishException );
 }
 
+TEST( MessageLookupTest, constants )
+{
+  namespace mt = ros::message_traits;
+  MessageOnlyDescriptionProvider provider;
+  auto description = provider.registerMessageByDefinition( mt::datatype<ros_babel_fish_test_msgs::TestMessage>(),
+                                                           mt::definition<ros_babel_fish_test_msgs::TestMessage>());
+  std::map<std::string, Message::ConstPtr> constant_map = description->message_template->constants;
+  ASSERT_EQ( constant_map.size(), 4 );
+  ASSERT_NE( constant_map.find( "FLAG1" ), constant_map.end());
+  ASSERT_EQ( constant_map["FLAG1"]->type(), MessageTypes::Bool );
+  ASSERT_EQ( constant_map["FLAG1"]->value<bool>(), ros_babel_fish_test_msgs::TestMessage::FLAG1 );
+  ASSERT_NE( constant_map.find( "FLAG2" ), constant_map.end());
+  ASSERT_EQ( constant_map["FLAG2"]->type(), MessageTypes::Bool );
+  ASSERT_EQ( constant_map["FLAG2"]->value<bool>(), ros_babel_fish_test_msgs::TestMessage::FLAG2 );
+  ASSERT_NE( constant_map.find( "FLAG3" ), constant_map.end());
+  ASSERT_EQ( constant_map["FLAG3"]->type(), MessageTypes::Bool );
+  ASSERT_EQ( constant_map["FLAG3"]->value<bool>(), ros_babel_fish_test_msgs::TestMessage::FLAG3 );
+  ASSERT_NE( constant_map.find( "FLAG4" ), constant_map.end());
+  ASSERT_EQ( constant_map["FLAG4"]->type(), MessageTypes::Bool );
+  ASSERT_EQ( constant_map["FLAG4"]->value<bool>(), ros_babel_fish_test_msgs::TestMessage::FLAG4 );
+}
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );

--- a/ros_babel_fish/test/message_lookup.cpp
+++ b/ros_babel_fish/test/message_lookup.cpp
@@ -19,6 +19,8 @@
 #include <geometry_msgs/Vector3Stamped.h>
 #include <geometry_msgs/WrenchStamped.h>
 
+#include <ros_babel_fish_test_msgs/TestMessage.h>
+
 #include <std_msgs/Bool.h>
 #include <std_msgs/Byte.h>
 #include <std_msgs/ByteMultiArray.h>
@@ -143,6 +145,8 @@ TEST( MessageLookupTest, integratedDescriptionProvider )
   EXPECT_TRUE((compareDescription<std_msgs::Float32, IntegratedDescriptionProvider>()));
   EXPECT_TRUE((compareDescription<std_msgs::String, IntegratedDescriptionProvider>()));
   EXPECT_TRUE((compareDescription<std_msgs::Time, IntegratedDescriptionProvider>()));
+
+  EXPECT_TRUE((compareDescription<ros_babel_fish_test_msgs::TestMessage, IntegratedDescriptionProvider>()));
 }
 
 TEST( MessageLookupTest, messageOnlyDescriptionProvider )

--- a/ros_babel_fish/test/service_lookup.cpp
+++ b/ros_babel_fish/test/service_lookup.cpp
@@ -14,6 +14,7 @@
 #include <rosapi/DeleteParam.h>
 #include <rosapi/GetActionServers.h>
 
+// Workaround because GetParamRequest has a member called default which is a reserved keyword in C++
 #define default mdefault
 
 #include <rosapi/GetParam.h>

--- a/ros_babel_fish_test_msgs/CMakeLists.txt
+++ b/ros_babel_fish_test_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(ros_babel_fish_test_msgs)
+cmake_minimum_required(VERSION 3.5.1)
+project(ros_babel_fish_test_msgs VERSION 0.9.1)
 
 find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation std_msgs geometry_msgs)
 

--- a/ros_babel_fish_test_msgs/msg/TestMessage.msg
+++ b/ros_babel_fish_test_msgs/msg/TestMessage.msg
@@ -16,7 +16,7 @@ time t
 duration d
 geometry_msgs/Point[] point_arr # more comment
 
-bool FLAG1 = 1
-bool FLAG2 = 0
-bool FLAG3 = True
+bool FLAG1 =1
+bool FLAG2= 0
+bool FLAG3=True
 bool FLAG4 = False

--- a/ros_babel_fish_test_msgs/msg/TestMessage.msg
+++ b/ros_babel_fish_test_msgs/msg/TestMessage.msg
@@ -15,3 +15,8 @@ string str## Two comment signs # and a third
 time t
 duration d
 geometry_msgs/Point[] point_arr # more comment
+
+bool FLAG1 = 1
+bool FLAG2 = 0
+bool FLAG3 = True
+bool FLAG4 = False


### PR DESCRIPTION
Hi! Thank you for creating and sharing this excellent library.

Currently, only integers are accepted as boolean constants in message definitions. While ROS documentation does not specify which values should be supported, the message definition parser accepts any Python literal and evaluates its truthiness:
https://github.com/ros/genmsg/blob/7d8b6ce6f43b6e39ea8261125d270f2d3062356f/src/genmsg/msg_loader.py#L185
Also, `genpy` uses `False` as the default value for booleans: https://github.com/ros/genpy/blob/acf8eb7e8cd464af6650619961d8ff3c4f4a6ac8/src/genpy/generator.py#L172

Supporting any Python literal would be too much, obviously, but supporting `True` and `False` seems like a reasonable addition. This PR does just that.