### PR TITLE
Add a missing virtual destructor to a virtual base class

### DIFF
--- a/ros_babel_fish/include/ros_babel_fish/generation/description_provider.h
+++ b/ros_babel_fish/include/ros_babel_fish/generation/description_provider.h
@@ -37,6 +37,8 @@ public:
 
   DescriptionProvider();
 
+  virtual ~DescriptionProvider() = default;
+
   MessageDescription::ConstPtr getMessageDescription( const std::string &type );
 
   MessageDescription::ConstPtr getMessageDescription( const BabelFishMessage &msg );


### PR DESCRIPTION
Fixes
> warning: destructor called on non-final 'ros_babel_fish::IntegratedDescriptionProvider' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]