### PR TITLE
Add noetic to CI, improvements to type safety checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ install:
   # Create the devel/setup.bash (run catkin_make with an empty workspace) and
   # source it to set the path variables.
   - cd ~/catkin_ws
-  - catkin config -j 2
-  - catkin build
+  - catkin config -j 2 # To avoid out-of-memory errors on build
+  - CXXFLAGS=-Werror catkin build
   - source devel/setup.bash
   # Add the package under integration to the workspace using a symlink.
   - cd ~/catkin_ws/src
@@ -81,7 +81,7 @@ before_script:
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - cd ~/catkin_ws
-  - catkin build
+  - CXXFLAGS=-Werror catkin build
   # Run the tests, ensuring the path is set correctly.
   - source devel/setup.bash
   - catkin run_tests && catkin_test_results

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ env:
 
 # Install system dependencies, namely a very barebones ROS setup.
 before_install:
+  - sudo apt-get install dpkg curl
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+  - curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install dpkg
   - if [ $ROS_DISTRO = noetic ]; then PYTHON=python3; else PYTHON=python; fi
   - sudo apt-get install -y $PYTHON-catkin-pkg $PYTHON-catkin-tools $PYTHON-rosdep $PYTHON-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-code-coverage
   - source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ matrix:
     arch: arm64
     dist: bionic
     env: ROS_DISTRO=melodic
+  - name: "Focal noetic AMD64"
+    arch: amd64
+    dist: focal
+    env: ROS_DISTRO=noetic
+  - name: "Focal noetic ARM64"
+    arch: arm64
+    dist: focal
+    env: ROS_DISTRO=noetic
 
 # Configuration variables. All variables are global now, but this can be used to
 # trigger a build matrix for different ROS distributions if desired.
@@ -36,7 +44,8 @@ before_install:
   - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-code-coverage
+  - if [ $ROS_DISTRO = noetic ]; then PYTHON=python3; else PYTHON=python; fi
+  - sudo apt-get install -y $PYTHON-catkin-pkg $PYTHON-catkin-tools $PYTHON-rosdep $PYTHON-wstool ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-code-coverage
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
@@ -50,6 +59,7 @@ install:
   # Create the devel/setup.bash (run catkin_make with an empty workspace) and
   # source it to set the path variables.
   - cd ~/catkin_ws
+  - catkin config -j 2
   - catkin build
   - source devel/setup.bash
   # Add the package under integration to the workspace using a symlink.

--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -11,7 +11,7 @@ endif ()
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-add_definitions(-Wall -Wextra -Wno-pragmas)
+add_definitions(-Wall -Wextra)
 
 #set(CMAKE_BUILD_TYPE "Debug")
 

--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -11,7 +11,7 @@ endif ()
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-add_definitions(-Wall -Wextra)
+add_definitions(-Wall -Wextra -Wno-pragmas)
 
 #set(CMAKE_BUILD_TYPE "Debug")
 

--- a/ros_babel_fish/examples/any_subscriber.cpp
+++ b/ros_babel_fish/examples/any_subscriber.cpp
@@ -10,8 +10,8 @@
 
 /*!
  * The following example demonstrates how to subscribe to a topic of any type, retrieve type information such as the
- * topic's datatype the MD% sum and the message definition, and traverse the message's content.
- * The datatype, md5 sum, message definition and the message's content are dumped to the console whenever a new message
+ * topic's datatype, the MD5 sum and the message definition, and traverse the message's content.
+ * The datatype, MD5 sum, message definition and the message's content are dumped to the console whenever a new message
  * is received.
  */
 

--- a/ros_babel_fish/examples/message_info.cpp
+++ b/ros_babel_fish/examples/message_info.cpp
@@ -18,7 +18,7 @@ int main( int argc, char **argv )
 
   BabelFish babel_fish;
   MessageDescription::ConstPtr message_description = babel_fish.descriptionProvider()->getMessageDescription( argv[1] );
-  if (message_description == nullptr)
+  if ( message_description == nullptr )
   {
     std::cerr << "No message definition for '" << argv[1] << "' found!" << std::endl;
     return 1;

--- a/ros_babel_fish/examples/service_info.cpp
+++ b/ros_babel_fish/examples/service_info.cpp
@@ -18,7 +18,7 @@ int main( int argc, char **argv )
 
   BabelFish babel_fish;
   ServiceDescription::ConstPtr message_description = babel_fish.descriptionProvider()->getServiceDescription( argv[1] );
-  if (message_description == nullptr)
+  if ( message_description == nullptr )
   {
     std::cerr << "No service definition for '" << argv[1] << "' found!" << std::endl;
     return 1;

--- a/ros_babel_fish/include/ros_babel_fish/babel_fish_message.h
+++ b/ros_babel_fish/include/ros_babel_fish/babel_fish_message.h
@@ -25,9 +25,9 @@ public:
 
   BabelFishMessage();
 
-  BabelFishMessage(const BabelFishMessage &other);
+  BabelFishMessage( const BabelFishMessage &other );
 
-  BabelFishMessage &operator=(const BabelFishMessage &other);
+  BabelFishMessage &operator=( const BabelFishMessage &other );
 
   virtual ~BabelFishMessage();
 

--- a/ros_babel_fish/include/ros_babel_fish/macros.h
+++ b/ros_babel_fish/include/ros_babel_fish/macros.h
@@ -4,7 +4,7 @@
 #ifndef ROS_BABEL_FISH_MACROS_H
 #define ROS_BABEL_FISH_MACROS_H
 
-#define RBF_TEMPLATE_CALL(function, type, args...) { \
+#define RBF_TEMPLATE_CALL( function, type, args... ) { \
   switch (type) \
   { \
     case MessageTypes::Compound: \
@@ -58,7 +58,7 @@
   } \
 }
 
-#define RBF_TEMPLATE_CALL_VALUE_TYPES(function, type, args...) { \
+#define RBF_TEMPLATE_CALL_VALUE_TYPES( function, type, args... ) { \
   switch (type) \
   { \
     case MessageTypes::Bool: \

--- a/ros_babel_fish/include/ros_babel_fish/message_extractor.h
+++ b/ros_babel_fish/include/ros_babel_fish/message_extractor.h
@@ -23,7 +23,7 @@ enum MessageOffsetType
   ArrayElement // If pointing to specific array element, will check if array has enough elements
 };
 }
-using MessageOffsetType  = MessageOffsetTypes::MessageOffsetType;
+using MessageOffsetType = MessageOffsetTypes::MessageOffsetType;
 
 class MessageOffset
 {

--- a/ros_babel_fish/include/ros_babel_fish/messages/internal/value_compatibility.h
+++ b/ros_babel_fish/include/ros_babel_fish/messages/internal/value_compatibility.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Stefan Fabian. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef ROS_BABEL_FISH_VALUE_COMPATIBILITY_H
+#define ROS_BABEL_FISH_VALUE_COMPATIBILITY_H
+
+#include <limits>
+
+namespace ros_babel_fish
+{
+//! Internal namespace not for public use, may change at any time.
+namespace internal
+{
+// Backport of C++20's std::remove_cvref
+template<class T>
+struct rm_cvref
+{
+  typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
+};
+template<class T>
+using rm_cvref_t = typename rm_cvref<T>::type;
+
+// is_integral is necessary to avoid a CLang tidy warning
+template<typename T, typename U>
+typename std::enable_if<
+  std::is_integral<T>::value &&
+  std::numeric_limits<T>::is_signed && !std::numeric_limits<U>::is_signed, bool>::type
+constexpr inBounds( const T &val )
+{
+  return val >= 0 && static_cast<typename std::make_unsigned<T>::type >( val ) <= std::numeric_limits<U>::max();
+}
+
+template<typename T, typename U>
+typename std::enable_if<
+  std::is_integral<T>::value &&
+  !std::numeric_limits<T>::is_signed && std::numeric_limits<U>::is_signed &&
+  std::numeric_limits<T>::digits >= std::numeric_limits<U>::digits, bool>::type
+constexpr inBounds( const T &val )
+{
+  return val <= static_cast<T>(std::numeric_limits<U>::max());
+}
+
+template<typename T, typename U>
+typename std::enable_if<
+  std::is_integral<T>::value &&
+!std::numeric_limits<T>::is_signed && std::numeric_limits<U>::is_signed &&
+std::numeric_limits<T>::digits < std::numeric_limits<U>::digits, bool>::type
+constexpr inBounds( const T &val )
+{
+  return static_cast<U>(val) <= std::numeric_limits<U>::max();
+}
+
+template<typename T, typename U>
+typename std::enable_if<
+  std::is_integral<T>::value &&
+  std::numeric_limits<T>::is_signed == std::numeric_limits<U>::is_signed, bool>::type
+constexpr inBounds( const T &val )
+{
+  return std::numeric_limits<U>::min() <= val && val <= std::numeric_limits<U>::max();
+}
+
+template<typename T, typename U>
+typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+constexpr inBounds( const T &val )
+{
+  return static_cast<T>(std::numeric_limits<U>::min()) <= val && val <= static_cast<T>(std::numeric_limits<U>::max());
+}
+
+/**
+ * Returns true if type T can always be stored in U without overflowing.
+ */
+template<typename T, typename U>
+typename std::enable_if<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value, bool>::type
+constexpr isCompatible()
+{
+  // See https://en.cppreference.com/w/cpp/types/numeric_limits/digits
+  // + 1 added because ::digits returns nbits-1 for signed types.
+  return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
+         std::is_floating_point<U>::value ||
+         (std::is_integral<T>::value &&
+          !(std::is_signed<T>::value && std::is_unsigned<U>::value) &&
+          (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
+}
+
+}
+}
+
+#endif //ROS_BABEL_FISH_VALUE_COMPATIBILITY_H

--- a/ros_babel_fish/src/babel_fish.cpp
+++ b/ros_babel_fish/src/babel_fish.cpp
@@ -61,7 +61,7 @@ Message::Ptr BabelFish::translateMessage( const BabelFishMessage &msg )
   const MessageTemplate::ConstPtr &msg_template = message_description->message_template;
   const uint8_t *stream = msg.buffer();
   size_t bytes_read = 0;
-  if (stream == nullptr)
+  if ( stream == nullptr )
   {
     return std::make_shared<CompoundMessage>( msg_template );
   }

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -31,8 +31,9 @@ namespace
 {
 
 // Backport of C++20's std::remove_cvref
-template< class T >
-struct rm_cvref {
+template<class T>
+struct rm_cvref
+{
   typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
 };
 template<class T>
@@ -41,8 +42,8 @@ using rm_cvref_t = typename rm_cvref<T>::type;
 // is_integral is necessary to avoid a CLang tidy warning
 template<typename T, typename U>
 typename std::enable_if<
-    std::is_integral<T>::value &&
-    std::numeric_limits<T>::is_signed && !std::numeric_limits<U>::is_signed, bool>::type
+  std::is_integral<T>::value &&
+  std::numeric_limits<T>::is_signed && !std::numeric_limits<U>::is_signed, bool>::type
 constexpr inBounds( const T &val )
 {
   return val >= 0 && static_cast<typename std::make_unsigned<T>::type >( val ) <= std::numeric_limits<U>::max();
@@ -106,26 +107,26 @@ template<typename T, typename U>
 void assignValue( Message *m, const T &value )
 {
   using namespace message_type_traits;
-  if ( !isCompatible<T, U>() )
+  if ( !isCompatible<T, U>())
   {
-    if ( !inBounds<T, U>( value ) )
+    if ( !inBounds<T, U>( value ))
     {
       throw BabelFishException(
-          "Value does not fit into value message! Make sure you're using the correct type or at least stay within the range of values for the message type!");
+        "Value does not fit into value message! Make sure you're using the correct type or at least stay within the range of values for the message type!" );
     }
 #if RBF_WARN_ON_INCOMPATIBLE_TYPE
     ROS_WARN_ONCE_NAMED( "RosBabelFish",
                          "Assigned value fits but the type of the assignment can not be converted without loss of information in some cases! This message is printed only once!" );
 #endif
   }
-  m->as<ValueMessage<U>>().setValue( static_cast<U>(value) );
+  m->as<ValueMessage<U>>().setValue( static_cast<U>(value));
 }
 
 template<typename T>
 void assignToValueMessage( Message *m, const T &value )
 {
   using namespace message_type_traits;
-  switch ( m->type() )
+  switch ( m->type())
   {
     case MessageTypes::Bool:
       throw BabelFishException( "Can not assign non-boolean value to a boolean ValueMessage!" );
@@ -271,9 +272,9 @@ U obtainValue( const Message *m )
 {
   using namespace message_type_traits;
   T val = m->as<ValueMessage<T>>().getValue();
-  if ( !isCompatible<T, U>() )
+  if ( !isCompatible<T, U>())
   {
-    if ( !inBounds<T, U>( val ) )
+    if ( !inBounds<T, U>( val ))
     {
       throw BabelFishException( "Value does not fit into casted type!" );
     }

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -100,6 +100,7 @@ constexpr isCompatible()
   return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
          std::is_floating_point<U>::value ||
          (std::is_integral<T>::value &&
+          !(std::is_signed<T>::value && std::is_unsigned<U>::value) &&
           (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
 }
 

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -51,7 +51,18 @@ constexpr inBounds( const T &val )
 template<typename T, typename U>
 typename std::enable_if<
   std::is_integral<T>::value &&
-  !std::numeric_limits<T>::is_signed && std::numeric_limits<U>::is_signed, bool>::type
+  !std::numeric_limits<T>::is_signed && std::numeric_limits<U>::is_signed &&
+  std::numeric_limits<T>::digits >= std::numeric_limits<U>::digits, bool>::type
+constexpr inBounds( const T &val )
+{
+  return val <= static_cast<T>(std::numeric_limits<U>::max());
+}
+
+template<typename T, typename U>
+typename std::enable_if<
+  std::is_integral<T>::value &&
+  !std::numeric_limits<T>::is_signed && std::numeric_limits<U>::is_signed &&
+  std::numeric_limits<T>::digits < std::numeric_limits<U>::digits, bool>::type
 constexpr inBounds( const T &val )
 {
   return val <= std::numeric_limits<U>::max();

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -105,7 +105,7 @@ template<typename T, typename U>
 void assignValue( Message *m, const T &value )
 {
   using namespace message_type_traits;
-  if ( m->type() != message_type<T>::value && !isCompatible<T, U>() )
+  if ( !isCompatible<T, U>() )
   {
     if ( !inBounds<T, U>( value ) )
     {
@@ -124,7 +124,7 @@ template<typename T>
 void assignToValueMessage( Message *m, const T &value )
 {
   using namespace message_type_traits;
-  switch ( m->type())
+  switch ( m->type() )
   {
     case MessageTypes::Bool:
       throw BabelFishException( "Can not assign non-boolean value to a boolean ValueMessage!" );
@@ -270,7 +270,7 @@ U obtainValue( const Message *m )
 {
   using namespace message_type_traits;
   T val = m->as<ValueMessage<T>>().getValue();
-  if ( m->type() != message_type<U>::value && !isCompatible<T, U>() )
+  if ( !isCompatible<T, U>() )
   {
     if ( !inBounds<T, U>( val ) )
     {

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -82,10 +82,7 @@ template<typename T, typename U>
 typename std::enable_if<std::is_floating_point<T>::value, bool>::type
 constexpr inBounds( const T &val )
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-int-float-conversion"
-  return std::numeric_limits<U>::min() <= val && val <= std::numeric_limits<U>::max();
-#pragma GCC diagnostic pop
+  return static_cast<T>(std::numeric_limits<U>::min()) <= val && val <= static_cast<T>(std::numeric_limits<U>::max());
 }
 
 /**

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -88,7 +88,7 @@ constexpr inBounds( const T &val )
 }
 
 /**
- * Returns true if type T can always be stored in U without truncation or loss of precision.
+ * Returns true if type T can always be stored in U without overflowing.
  */
 template<typename T, typename U>
 typename std::enable_if<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value, bool>::type
@@ -97,7 +97,8 @@ constexpr isCompatible()
   // See https://en.cppreference.com/w/cpp/types/numeric_limits/digits
   // + 1 added because ::digits returns nbits-1 for signed types.
   return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
-         ((std::is_integral<T>::value || std::is_floating_point<U>::value) &&
+         std::is_floating_point<U>::value ||
+         (std::is_integral<T>::value &&
           (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
 }
 

--- a/ros_babel_fish/src/message.cpp
+++ b/ros_babel_fish/src/message.cpp
@@ -65,7 +65,7 @@ typename std::enable_if<
   std::numeric_limits<T>::digits < std::numeric_limits<U>::digits, bool>::type
 constexpr inBounds( const T &val )
 {
-  return val <= std::numeric_limits<U>::max();
+  return static_cast<U>(val) <= std::numeric_limits<U>::max();
 }
 
 template<typename T, typename U>

--- a/ros_babel_fish/test/message.cpp
+++ b/ros_babel_fish/test/message.cpp
@@ -712,6 +712,7 @@ constexpr isCompatible()
   return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
          std::is_floating_point<U>::value ||
          (std::is_integral<T>::value &&
+          !(std::is_signed<T>::value && std::is_unsigned<U>::value) &&
           (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
 }
 

--- a/ros_babel_fish/test/message.cpp
+++ b/ros_babel_fish/test/message.cpp
@@ -691,18 +691,17 @@ TEST( MessageTest, arrayMessage )
   }
 }
 
-namespace {
-
 // Backport of C++20's std::remove_cvref
-template< class T >
-struct rm_cvref {
+template<class T>
+struct rm_cvref
+{
   typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
 };
 template<class T>
 using rm_cvref_t = typename rm_cvref<T>::type;
 
 /**
- * Returns true if type T can always be stored in U without truncation or loss of precision.
+ * Returns true if type T can always be stored in U without overflowing.
  */
 template<typename T, typename U>
 typename std::enable_if<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value, bool>::type
@@ -711,120 +710,119 @@ constexpr isCompatible()
   // See https://en.cppreference.com/w/cpp/types/numeric_limits/digits
   // + 1 added because ::digits returns nbits-1 for signed types.
   return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
-         ((std::is_integral<T>::value || std::is_floating_point<U>::value) &&
+         std::is_floating_point<U>::value ||
+         (std::is_integral<T>::value &&
           (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
-}
-
 }
 
 TEST( MessageTest, isCompatible )
 {
-  ASSERT_EQ( (isCompatible<bool, bool>()), true );
-  ASSERT_EQ( (isCompatible<bool, uint8_t>()), true );
-  ASSERT_EQ( (isCompatible<bool, float>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, bool>()), false );
-  ASSERT_EQ( (isCompatible<int8_t, bool>()), false );
-  ASSERT_EQ( (isCompatible<float, bool>()), false );
-  ASSERT_EQ( (isCompatible<uint8_t, uint8_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, uint16_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, uint32_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint8_t, int16_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, int32_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, float>()), true );
-  ASSERT_EQ( (isCompatible<uint8_t, double>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint16_t, uint16_t>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, uint32_t>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint16_t, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<uint16_t, int32_t>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, float>()), true );
-  ASSERT_EQ( (isCompatible<uint16_t, double>()), true );
-  ASSERT_EQ( (isCompatible<uint32_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, uint32_t>()), true );
-  ASSERT_EQ( (isCompatible<uint32_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint32_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, int32_t>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint32_t, float>()), false );
-  ASSERT_EQ( (isCompatible<uint32_t, double>()), true );
-  ASSERT_EQ( (isCompatible<uint64_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, uint32_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<uint64_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, int32_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, int64_t>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, float>()), false );
-  ASSERT_EQ( (isCompatible<uint64_t, double>()), false );
-  ASSERT_EQ( (isCompatible<int8_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<int8_t, uint16_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, uint32_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, int8_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, int16_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, int32_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, float>()), true );
-  ASSERT_EQ( (isCompatible<int8_t, double>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<int16_t, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<int16_t, uint32_t>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<int16_t, int16_t>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, int32_t>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, float>()), true );
-  ASSERT_EQ( (isCompatible<int16_t, double>()), true );
-  ASSERT_EQ( (isCompatible<int32_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, uint32_t>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, uint64_t>()), true );
-  ASSERT_EQ( (isCompatible<int32_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, int32_t>()), true );
-  ASSERT_EQ( (isCompatible<int32_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<int32_t, float>()), false );
-  ASSERT_EQ( (isCompatible<int32_t, double>()), true );
-  ASSERT_EQ( (isCompatible<int64_t, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, uint32_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, uint64_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, int32_t>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, int64_t>()), true );
-  ASSERT_EQ( (isCompatible<int64_t, float>()), false );
-  ASSERT_EQ( (isCompatible<int64_t, double>()), false );
-  ASSERT_EQ( (isCompatible<float, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<float, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<float, uint32_t>()), false );
-  ASSERT_EQ( (isCompatible<float, uint64_t>()), false );
-  ASSERT_EQ( (isCompatible<float, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<float, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<float, int32_t>()), false );
-  ASSERT_EQ( (isCompatible<float, int64_t>()), false );
-  ASSERT_EQ( (isCompatible<float, float>()), true );
-  ASSERT_EQ( (isCompatible<float, double>()), true );
-  ASSERT_EQ( (isCompatible<double, uint8_t>()), false );
-  ASSERT_EQ( (isCompatible<double, uint16_t>()), false );
-  ASSERT_EQ( (isCompatible<double, uint32_t>()), false );
-  ASSERT_EQ( (isCompatible<double, uint64_t>()), false );
-  ASSERT_EQ( (isCompatible<double, int8_t>()), false );
-  ASSERT_EQ( (isCompatible<double, int16_t>()), false );
-  ASSERT_EQ( (isCompatible<double, int32_t>()), false );
-  ASSERT_EQ( (isCompatible<double, int64_t>()), false );
-  ASSERT_EQ( (isCompatible<double, float>()), false );
-  ASSERT_EQ( (isCompatible<double, double>()), true );
+  ASSERT_EQ((isCompatible<bool, bool>()), true );
+  ASSERT_EQ((isCompatible<bool, uint8_t>()), true );
+  ASSERT_EQ((isCompatible<bool, float>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, bool>()), false );
+  ASSERT_EQ((isCompatible<int8_t, bool>()), false );
+  ASSERT_EQ((isCompatible<float, bool>()), false );
+  ASSERT_EQ((isCompatible<uint8_t, uint8_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, uint16_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, uint32_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<uint8_t, int16_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, int32_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, float>()), true );
+  ASSERT_EQ((isCompatible<uint8_t, double>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<uint16_t, uint16_t>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, uint32_t>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<uint16_t, int16_t>()), false );
+  ASSERT_EQ((isCompatible<uint16_t, int32_t>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, float>()), true );
+  ASSERT_EQ((isCompatible<uint16_t, double>()), true );
+  ASSERT_EQ((isCompatible<uint32_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<uint32_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<uint32_t, uint32_t>()), true );
+  ASSERT_EQ((isCompatible<uint32_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<uint32_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<uint32_t, int16_t>()), false );
+  ASSERT_EQ((isCompatible<uint32_t, int32_t>()), false );
+  ASSERT_EQ((isCompatible<uint32_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<uint32_t, float>()), true );
+  ASSERT_EQ((isCompatible<uint32_t, double>()), true );
+  ASSERT_EQ((isCompatible<uint64_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<uint64_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, int16_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, int32_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, int64_t>()), false );
+  ASSERT_EQ((isCompatible<uint64_t, float>()), true );
+  ASSERT_EQ((isCompatible<uint64_t, double>()), true );
+  ASSERT_EQ((isCompatible<int8_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<int8_t, uint16_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, uint32_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, int8_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, int16_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, int32_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, float>()), true );
+  ASSERT_EQ((isCompatible<int8_t, double>()), true );
+  ASSERT_EQ((isCompatible<int16_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<int16_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<int16_t, uint32_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<int16_t, int16_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, int32_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, float>()), true );
+  ASSERT_EQ((isCompatible<int16_t, double>()), true );
+  ASSERT_EQ((isCompatible<int32_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<int32_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<int32_t, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<int32_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int32_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<int32_t, int16_t>()), false );
+  ASSERT_EQ((isCompatible<int32_t, int32_t>()), true );
+  ASSERT_EQ((isCompatible<int32_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<int32_t, float>()), true );
+  ASSERT_EQ((isCompatible<int32_t, double>()), true );
+  ASSERT_EQ((isCompatible<int64_t, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, uint64_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, int8_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, int16_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, int32_t>()), false );
+  ASSERT_EQ((isCompatible<int64_t, int64_t>()), true );
+  ASSERT_EQ((isCompatible<int64_t, float>()), true );
+  ASSERT_EQ((isCompatible<int64_t, double>()), true );
+  ASSERT_EQ((isCompatible<float, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<float, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<float, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<float, uint64_t>()), false );
+  ASSERT_EQ((isCompatible<float, int8_t>()), false );
+  ASSERT_EQ((isCompatible<float, int16_t>()), false );
+  ASSERT_EQ((isCompatible<float, int32_t>()), false );
+  ASSERT_EQ((isCompatible<float, int64_t>()), false );
+  ASSERT_EQ((isCompatible<float, float>()), true );
+  ASSERT_EQ((isCompatible<float, double>()), true );
+  ASSERT_EQ((isCompatible<double, uint8_t>()), false );
+  ASSERT_EQ((isCompatible<double, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<double, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<double, uint64_t>()), false );
+  ASSERT_EQ((isCompatible<double, int8_t>()), false );
+  ASSERT_EQ((isCompatible<double, int16_t>()), false );
+  ASSERT_EQ((isCompatible<double, int32_t>()), false );
+  ASSERT_EQ((isCompatible<double, int64_t>()), false );
+  ASSERT_EQ((isCompatible<double, float>()), true );
+  ASSERT_EQ((isCompatible<double, double>()), true );
 }
 
 int main( int argc, char **argv )

--- a/ros_babel_fish/test/message.cpp
+++ b/ros_babel_fish/test/message.cpp
@@ -239,11 +239,11 @@ TEST( MessageTest, message )
     EXPECT_DOUBLE_EQ( vm.value<double>(), 42.0 );
     EXPECT_NO_THROW( vm = 50.0f );
     EXPECT_FLOAT_EQ( vm.value<float>(), 50.0f );
-    EXPECT_THROW( vm = 42.0, BabelFishException );
-    EXPECT_FLOAT_EQ( vm.value<float>(), 50.0f );
+    EXPECT_NO_THROW( vm = 42.0 );
+    EXPECT_FLOAT_EQ( vm.value<float>(), 42.0f );
     EXPECT_NO_THROW( vm = 42 );
     EXPECT_FLOAT_EQ( vm.value<float>(), 42.0f );
-    EXPECT_THROW( vm.value<int32_t>(), BabelFishException );
+    EXPECT_EQ( vm.value<int32_t>(), 42 );
 
     ASSERT_EQ( vm._sizeInBytes(), 4U );
     uint8_t stream[4];
@@ -259,14 +259,14 @@ TEST( MessageTest, message )
     ValueMessage<double> vm_in( 42.0 );
     Message &vm = vm_in;
     EXPECT_DOUBLE_EQ( vm.value<double>(), 42.0 );
-    EXPECT_THROW( vm.value<float>(), BabelFishException );
+    EXPECT_FLOAT_EQ( vm.value<float>(), 42.0f );
     EXPECT_NO_THROW( vm = 50.0f );
     EXPECT_DOUBLE_EQ( vm.value<double>(), 50.0 );
     EXPECT_NO_THROW( vm = 42.0 );
     EXPECT_DOUBLE_EQ( vm.value<double>(), 42.0 );
     EXPECT_NO_THROW( vm = 50 );
     EXPECT_DOUBLE_EQ( vm.value<double>(), 50.0 );
-    EXPECT_THROW( vm.value<int32_t>(), BabelFishException );
+    EXPECT_EQ( vm.value<int32_t>(), 50 );
 
     ASSERT_EQ( vm._sizeInBytes(), 8U );
     uint8_t stream[8];
@@ -689,6 +689,142 @@ TEST( MessageTest, arrayMessage )
     ArrayMessage<bool> am( 20, true );
     EXPECT_THROW( am.push_back( true ), BabelFishException );
   }
+}
+
+namespace {
+
+// Backport of C++20's std::remove_cvref
+template< class T >
+struct rm_cvref {
+  typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
+};
+template<class T>
+using rm_cvref_t = typename rm_cvref<T>::type;
+
+/**
+ * Returns true if type T can always be stored in U without truncation or loss of precision.
+ */
+template<typename T, typename U>
+typename std::enable_if<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value, bool>::type
+constexpr isCompatible()
+{
+  // See https://en.cppreference.com/w/cpp/types/numeric_limits/digits
+  // + 1 added because ::digits returns nbits-1 for signed types.
+  return std::is_same<rm_cvref_t<T>, rm_cvref_t<U>>::value ||
+         ((std::is_integral<T>::value || std::is_floating_point<U>::value) &&
+          (std::numeric_limits<T>::digits + 1 < std::numeric_limits<U>::digits));
+}
+
+}
+
+TEST( MessageTest, isCompatible )
+{
+  ASSERT_EQ( (isCompatible<bool, bool>()), true );
+  ASSERT_EQ( (isCompatible<bool, uint8_t>()), true );
+  ASSERT_EQ( (isCompatible<bool, float>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, bool>()), false );
+  ASSERT_EQ( (isCompatible<int8_t, bool>()), false );
+  ASSERT_EQ( (isCompatible<float, bool>()), false );
+  ASSERT_EQ( (isCompatible<uint8_t, uint8_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, uint16_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, uint32_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint8_t, int16_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, int32_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, float>()), true );
+  ASSERT_EQ( (isCompatible<uint8_t, double>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint16_t, uint16_t>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, uint32_t>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint16_t, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<uint16_t, int32_t>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, float>()), true );
+  ASSERT_EQ( (isCompatible<uint16_t, double>()), true );
+  ASSERT_EQ( (isCompatible<uint32_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, uint32_t>()), true );
+  ASSERT_EQ( (isCompatible<uint32_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint32_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, int32_t>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint32_t, float>()), false );
+  ASSERT_EQ( (isCompatible<uint32_t, double>()), true );
+  ASSERT_EQ( (isCompatible<uint64_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, uint32_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<uint64_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, int32_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, int64_t>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, float>()), false );
+  ASSERT_EQ( (isCompatible<uint64_t, double>()), false );
+  ASSERT_EQ( (isCompatible<int8_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<int8_t, uint16_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, uint32_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, int8_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, int16_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, int32_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, float>()), true );
+  ASSERT_EQ( (isCompatible<int8_t, double>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<int16_t, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<int16_t, uint32_t>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<int16_t, int16_t>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, int32_t>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, float>()), true );
+  ASSERT_EQ( (isCompatible<int16_t, double>()), true );
+  ASSERT_EQ( (isCompatible<int32_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, uint32_t>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, uint64_t>()), true );
+  ASSERT_EQ( (isCompatible<int32_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, int32_t>()), true );
+  ASSERT_EQ( (isCompatible<int32_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<int32_t, float>()), false );
+  ASSERT_EQ( (isCompatible<int32_t, double>()), true );
+  ASSERT_EQ( (isCompatible<int64_t, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, uint32_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, uint64_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, int32_t>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, int64_t>()), true );
+  ASSERT_EQ( (isCompatible<int64_t, float>()), false );
+  ASSERT_EQ( (isCompatible<int64_t, double>()), false );
+  ASSERT_EQ( (isCompatible<float, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<float, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<float, uint32_t>()), false );
+  ASSERT_EQ( (isCompatible<float, uint64_t>()), false );
+  ASSERT_EQ( (isCompatible<float, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<float, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<float, int32_t>()), false );
+  ASSERT_EQ( (isCompatible<float, int64_t>()), false );
+  ASSERT_EQ( (isCompatible<float, float>()), true );
+  ASSERT_EQ( (isCompatible<float, double>()), true );
+  ASSERT_EQ( (isCompatible<double, uint8_t>()), false );
+  ASSERT_EQ( (isCompatible<double, uint16_t>()), false );
+  ASSERT_EQ( (isCompatible<double, uint32_t>()), false );
+  ASSERT_EQ( (isCompatible<double, uint64_t>()), false );
+  ASSERT_EQ( (isCompatible<double, int8_t>()), false );
+  ASSERT_EQ( (isCompatible<double, int16_t>()), false );
+  ASSERT_EQ( (isCompatible<double, int32_t>()), false );
+  ASSERT_EQ( (isCompatible<double, int64_t>()), false );
+  ASSERT_EQ( (isCompatible<double, float>()), false );
+  ASSERT_EQ( (isCompatible<double, double>()), true );
 }
 
 int main( int argc, char **argv )

--- a/ros_babel_fish/test/message.cpp
+++ b/ros_babel_fish/test/message.cpp
@@ -764,9 +764,9 @@ TEST( MessageTest, isCompatible )
   ASSERT_EQ((isCompatible<uint64_t, float>()), true );
   ASSERT_EQ((isCompatible<uint64_t, double>()), true );
   ASSERT_EQ((isCompatible<int8_t, uint8_t>()), false );
-  ASSERT_EQ((isCompatible<int8_t, uint16_t>()), true );
-  ASSERT_EQ((isCompatible<int8_t, uint32_t>()), true );
-  ASSERT_EQ((isCompatible<int8_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int8_t, uint16_t>()), false );
+  ASSERT_EQ((isCompatible<int8_t, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<int8_t, uint64_t>()), false );
   ASSERT_EQ((isCompatible<int8_t, int8_t>()), true );
   ASSERT_EQ((isCompatible<int8_t, int16_t>()), true );
   ASSERT_EQ((isCompatible<int8_t, int32_t>()), true );
@@ -775,8 +775,8 @@ TEST( MessageTest, isCompatible )
   ASSERT_EQ((isCompatible<int8_t, double>()), true );
   ASSERT_EQ((isCompatible<int16_t, uint8_t>()), false );
   ASSERT_EQ((isCompatible<int16_t, uint16_t>()), false );
-  ASSERT_EQ((isCompatible<int16_t, uint32_t>()), true );
-  ASSERT_EQ((isCompatible<int16_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int16_t, uint32_t>()), false );
+  ASSERT_EQ((isCompatible<int16_t, uint64_t>()), false );
   ASSERT_EQ((isCompatible<int16_t, int8_t>()), false );
   ASSERT_EQ((isCompatible<int16_t, int16_t>()), true );
   ASSERT_EQ((isCompatible<int16_t, int32_t>()), true );
@@ -786,7 +786,7 @@ TEST( MessageTest, isCompatible )
   ASSERT_EQ((isCompatible<int32_t, uint8_t>()), false );
   ASSERT_EQ((isCompatible<int32_t, uint16_t>()), false );
   ASSERT_EQ((isCompatible<int32_t, uint32_t>()), false );
-  ASSERT_EQ((isCompatible<int32_t, uint64_t>()), true );
+  ASSERT_EQ((isCompatible<int32_t, uint64_t>()), false );
   ASSERT_EQ((isCompatible<int32_t, int8_t>()), false );
   ASSERT_EQ((isCompatible<int32_t, int16_t>()), false );
   ASSERT_EQ((isCompatible<int32_t, int32_t>()), true );

--- a/ros_babel_fish/test/message_comparison.h
+++ b/ros_babel_fish/test/message_comparison.h
@@ -362,23 +362,23 @@ bool MessageContentEqualImpl( const ros_babel_fish::Message &a, const geometry_m
   return MessageContentEqualImpl( a["pose"], b.pose, path + ".pose", result );
 }
 
-template <>
+template<>
 bool MessageContentEqualImpl( const ros_babel_fish::Message &a, const ros_babel_fish_test_msgs::TestMessage &b,
                               const std::string &path, ::testing::AssertionResult &result )
 {
-  if (!MessageContentEqualImpl( a["header"], b.header, path + ".header", result)) return false;
-  if (!MessageContentEqualImpl<bool>( a["b"], b.b, path + ".b", result)) return false;
-  if (!MessageContentEqualImpl( a["ui8"], b.ui8, path + ".ui8", result)) return false;
-  if (!MessageContentEqualImpl( a["ui16"], b.ui16, path + ".ui16", result)) return false;
-  if (!MessageContentEqualImpl( a["ui32"], b.ui32, path + ".ui32", result)) return false;
-  if (!MessageContentEqualImpl( a["ui64"], b.ui64, path + ".ui64", result)) return false;
-  if (!MessageContentEqualImpl( a["i8"], b.i8, path + ".i8", result)) return false;
-  if (!MessageContentEqualImpl( a["i16"], b.i16, path + ".i16", result)) return false;
-  if (!MessageContentEqualImpl( a["i32"], b.i32, path + ".i32", result)) return false;
-  if (!MessageContentEqualImpl( a["i64"], b.i64, path + ".i64", result)) return false;
-  if (!MessageContentEqualImpl( a["str"], b.str, path + ".str", result)) return false;
-  if (!MessageContentEqualImpl( a["t"], b.t, path + ".t", result)) return false;
-  return MessageContentEqualImpl(a["d"], b.d, path + ".d", result);
+  if ( !MessageContentEqualImpl( a["header"], b.header, path + ".header", result )) return false;
+  if ( !MessageContentEqualImpl<bool>( a["b"], b.b, path + ".b", result )) return false;
+  if ( !MessageContentEqualImpl( a["ui8"], b.ui8, path + ".ui8", result )) return false;
+  if ( !MessageContentEqualImpl( a["ui16"], b.ui16, path + ".ui16", result )) return false;
+  if ( !MessageContentEqualImpl( a["ui32"], b.ui32, path + ".ui32", result )) return false;
+  if ( !MessageContentEqualImpl( a["ui64"], b.ui64, path + ".ui64", result )) return false;
+  if ( !MessageContentEqualImpl( a["i8"], b.i8, path + ".i8", result )) return false;
+  if ( !MessageContentEqualImpl( a["i16"], b.i16, path + ".i16", result )) return false;
+  if ( !MessageContentEqualImpl( a["i32"], b.i32, path + ".i32", result )) return false;
+  if ( !MessageContentEqualImpl( a["i64"], b.i64, path + ".i64", result )) return false;
+  if ( !MessageContentEqualImpl( a["str"], b.str, path + ".str", result )) return false;
+  if ( !MessageContentEqualImpl( a["t"], b.t, path + ".t", result )) return false;
+  return MessageContentEqualImpl( a["d"], b.d, path + ".d", result );
 }
 
 template<>

--- a/ros_babel_fish/test/message_lookup.cpp
+++ b/ros_babel_fish/test/message_lookup.cpp
@@ -167,7 +167,7 @@ TEST( MessageLookupTest, constants )
   auto description = provider.registerMessageByDefinition( mt::datatype<ros_babel_fish_test_msgs::TestMessage>(),
                                                            mt::definition<ros_babel_fish_test_msgs::TestMessage>());
   std::map<std::string, Message::ConstPtr> constant_map = description->message_template->constants;
-  ASSERT_EQ( constant_map.size(), 4 );
+  ASSERT_EQ( constant_map.size(), 4U );
   ASSERT_NE( constant_map.find( "FLAG1" ), constant_map.end());
   ASSERT_EQ( constant_map["FLAG1"]->type(), MessageTypes::Bool );
   ASSERT_EQ( constant_map["FLAG1"]->value<bool>(), ros_babel_fish_test_msgs::TestMessage::FLAG1 );


### PR DESCRIPTION
I added noetic to the CI config and turned on `-Werror` for CI. The newer Ubuntu release in noetic also includes a newer gcc with improved warnings. Pretty much all of the warnings (except for #5) were related to the `isCompatible()` and `inBounds()` checks in `messages.cpp`:
* warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648.
* warning: comparison between signed and unsigned integer expressions.

Since that code does some tricky implicit casting and the warnings seemed relevant, I did not want to just dismiss them. However, I found the existing rules making use of SFINAE a bit hard to follow, so I created a simple test suite for `isCompatible()` that checks all arithmetic type pairs and rewrote that check from scratch.

`isCompatible()` now effectively checks that the conversion is guaranteed to safe:
* Integer types can safely fit within the other.
* Integer to floating point type conversion can be done without losing precision - that is, the integer can fit inside the mantissa.
* Floating point to integer is not permitted.
* Floating point to floating point is only allowed to the same or bigger type.

I also made `isCompatible()` and `inBounds()` constexpr and got rid of `isCompatible(const T &val)` and `m->type() != message_type<U>::value`. The latter is redundant to `isCompatible()` and thanks to `isCompatible()` being constexpr, most type conversion safety checks can be done at compile-time.