### PR TITLE
change exceptions to public inheritance

### DIFF
--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_location_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_location_exception.h
@@ -4,15 +4,15 @@
 #ifndef ROS_BABEL_FISH_INVALID_LOCATION_EXCEPTION_H
 #define ROS_BABEL_FISH_INVALID_LOCATION_EXCEPTION_H
 
-#include <ros/exception.h>
+#include "babel_fish_exception.h"
 
 namespace ros_babel_fish
 {
 
-class InvalidLocationException : public ros::Exception
+class InvalidLocationException : public BabelFishException
 {
 public:
-  explicit InvalidLocationException( const std::string &msg ) : ros::Exception( msg ) { }
+  explicit InvalidLocationException( const std::string &msg ) : BabelFishException( msg ) { }
 };
 } // ros_babel_fish
 

--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_location_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_location_exception.h
@@ -9,7 +9,7 @@
 namespace ros_babel_fish
 {
 
-class InvalidLocationException : ros::Exception
+class InvalidLocationException : public ros::Exception
 {
 public:
   explicit InvalidLocationException( const std::string &msg ) : ros::Exception( msg ) { }

--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_message_path_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_message_path_exception.h
@@ -9,7 +9,7 @@
 namespace ros_babel_fish
 {
 
-class InvalidMessagePathException : ros::Exception
+class InvalidMessagePathException : public ros::Exception
 {
 public:
   explicit InvalidMessagePathException( const std::string &msg ) : ros::Exception( msg ) { }

--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_message_path_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_message_path_exception.h
@@ -4,15 +4,15 @@
 #ifndef ROS_BABEL_FISH_INVALID_MESSAGE_PATH_EXCEPTION_H
 #define ROS_BABEL_FISH_INVALID_MESSAGE_PATH_EXCEPTION_H
 
-#include <ros/exception.h>
+#include "babel_fish_exception.h"
 
 namespace ros_babel_fish
 {
 
-class InvalidMessagePathException : public ros::Exception
+class InvalidMessagePathException : public BabelFishException
 {
 public:
-  explicit InvalidMessagePathException( const std::string &msg ) : ros::Exception( msg ) { }
+  explicit InvalidMessagePathException( const std::string &msg ) : BabelFishException( msg ) { }
 };
 } // ros_babel_fish
 

--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_template_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_template_exception.h
@@ -9,7 +9,7 @@
 namespace ros_babel_fish
 {
 
-class InvalidTemplateException : ros::Exception
+class InvalidTemplateException : public ros::Exception
 {
 public:
   explicit InvalidTemplateException( const std::string &msg ) : ros::Exception( msg ) { }

--- a/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_template_exception.h
+++ b/ros_babel_fish/include/ros_babel_fish/exceptions/invalid_template_exception.h
@@ -4,15 +4,15 @@
 #ifndef ROS_BABEL_FISH_INVALID_TEMPLATE_EXCEPTION_H
 #define ROS_BABEL_FISH_INVALID_TEMPLATE_EXCEPTION_H
 
-#include <ros/exception.h>
+#include "babel_fish_exception.h"
 
 namespace ros_babel_fish
 {
 
-class InvalidTemplateException : public ros::Exception
+class InvalidTemplateException : public BabelFishException
 {
 public:
-  explicit InvalidTemplateException( const std::string &msg ) : ros::Exception( msg ) { }
+  explicit InvalidTemplateException( const std::string &msg ) : BabelFishException( msg ) { }
 };
 } // ros_babel_fish
 


### PR DESCRIPTION
Private inheritance prevents getting exception messages which become private in the context. Better to switch to public inheritance.