### PR TITLE
Fix a small bug where translateMessage() will force latched to true

### DIFF
--- a/ros_babel_fish/include/ros_babel_fish/babel_fish.h
+++ b/ros_babel_fish/include/ros_babel_fish/babel_fish.h
@@ -87,6 +87,12 @@ public:
   BabelFishMessage::Ptr translateMessage( const Message &msg );
 
   /*!
+   * @copydoc BabelFish::translateMessage(const Message::ConstPtr&)
+   * @param latched This bool is passed to the headers
+   */
+  BabelFishMessage::Ptr translateMessage( const Message &msg, bool latched );
+
+  /*!
    * @copydetails BabelFish::translateMessage(const Message::ConstPtr&)
    * @param msg The input message
    * @param result Container for the serialized ROS compatible message

--- a/ros_babel_fish/src/babel_fish.cpp
+++ b/ros_babel_fish/src/babel_fish.cpp
@@ -79,6 +79,11 @@ BabelFishMessage::Ptr BabelFish::translateMessage( const Message::ConstPtr &msg 
 
 BabelFishMessage::Ptr BabelFish::translateMessage( const Message &msg )
 {
+  return translateMessage( msg, false );
+}
+
+BabelFishMessage::Ptr BabelFish::translateMessage( const Message &msg, bool latched )
+{
   auto compound_msg = dynamic_cast<const CompoundMessage *>(&msg);
   if ( compound_msg == nullptr )
     throw BabelFishException( "Tried to translate message that is not a compound message!" );
@@ -90,7 +95,7 @@ BabelFishMessage::Ptr BabelFish::translateMessage( const Message &msg )
   {
     throw BabelFishException( "BabelFish doesn't know a message of type: " + compound_msg->datatype());
   }
-  result->morph( description->md5, description->datatype, description->message_definition, "0" );
+  result->morph( description->md5, description->datatype, description->message_definition, latched );
   result->allocate( msg._sizeInBytes());
   msg.writeToStream( result->buffer());
   return result;
@@ -107,7 +112,7 @@ bool BabelFish::translateMessage( const Message &msg, BabelFishMessage &result )
   {
     throw BabelFishException( "BabelFish doesn't know a message of type: " + compound_msg->datatype());
   }
-  result.morph( description->md5, description->datatype, description->message_definition, "0" );
+  result.morph( description->md5, description->datatype, description->message_definition, false );
   result.allocate( msg._sizeInBytes());
   msg.writeToStream( result.buffer());
   return true;


### PR DESCRIPTION
Hi,
First of all thank you for this great library :)

I stumbled on a small "bug" in the code : the string `"0"` is passed to a `bool` argument.  This "0" is evaluated to "true" thus setting latched to true.
I changed this to false by default, because everywhere else in ROS and ros_babel_fish latched is set by default to false.
I also added a new method so we can set latched to "true" as before.
The change only adds a new method in the header, so it shouldn't break ABI.

